### PR TITLE
Feature/allow passing encoding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 erl_crash.dump
 *.ez
 /doc
+.elixir_ls/

--- a/lib/mail.ex
+++ b/lib/mail.ex
@@ -80,7 +80,7 @@ defmodule Mail do
 
       Mail.put_html(%Mail.Message{}, "<span>Some HTML</span>")
 
-  If a text part already exists this function will replace that existing
+  If a HTML part already exists this function will replace that existing
   part with the new part.
   """
   def put_html(%Mail.Message{multipart: true} = message, body) do
@@ -108,14 +108,12 @@ defmodule Mail do
   If multipart without part having `content-type` "text/html" will return `nil`
   """
   def get_html(%Mail.Message{multipart: true} = message) do
-    Enum.find(message.parts, fn
-      %Mail.Message{headers: %{"content-type" => "text/html"}} = message -> message
-      _ -> nil
-    end)
+    Enum.find(message.parts, &Mail.Message.match_content_type?(&1, "text/html"))
   end
 
-  def get_html(%Mail.Message{headers: %{"content-type" => "text/html"}} = message), do: message
-  def get_html(%Mail.Message{}), do: nil
+  def get_html(%Mail.Message{} = message) do
+    if Mail.Message.match_content_type?(message, "text/html"), do: message
+  end
 
   @doc """
   Add an attachment part to the message

--- a/lib/mail.ex
+++ b/lib/mail.ex
@@ -67,8 +67,12 @@ defmodule Mail do
     end)
   end
 
-  def get_text(%Mail.Message{headers: %{"content-type" => "text/plain" <> _}} = message), do: message
-  def get_text(%Mail.Message{headers: %{"content-type" => ["text/plain" | _]}} = message), do: message
+  def get_text(%Mail.Message{headers: %{"content-type" => "text/plain" <> _}} = message),
+    do: message
+
+  def get_text(%Mail.Message{headers: %{"content-type" => ["text/plain" | _]}} = message),
+    do: message
+
   def get_text(%Mail.Message{}), do: nil
 
   @doc """

--- a/lib/mail/parsers/rfc_2822.ex
+++ b/lib/mail/parsers/rfc_2822.ex
@@ -149,8 +149,8 @@ defmodule Mail.Parsers.RFC2822 do
 
   # Fixes invalid value: Wed, 14 10 2015 12:34:17
   def erl_from_timestamp(
-        <<date::binary-size(2), " ", month_digits::binary-size(2), " ", year::binary-size(4),
-          " ", hour::binary-size(2), ":", minute::binary-size(2), ":", second::binary-size(2),
+        <<date::binary-size(2), " ", month_digits::binary-size(2), " ", year::binary-size(4), " ",
+          hour::binary-size(2), ":", minute::binary-size(2), ":", second::binary-size(2),
           rest::binary>>
       ) do
     month_name = get_month_name(month_digits)

--- a/test/fixtures/multipart-jpeg-attachment-rendering.eml
+++ b/test/fixtures/multipart-jpeg-attachment-rendering.eml
@@ -8,13 +8,13 @@ Content-Type: multipart/mixed; boundary="2753118483D4F18DC5FD1F1A"
 Content-Type: multipart/alternative; boundary="DB28EC13A6576C8F20B92FD0"
 
 --DB28EC13A6576C8F20B92FD0
-Content-Type: text/plain
+Content-Type: text/plain; charset=utf-8
 Content-Transfer-Encoding: quoted-printable
 
 Some text
 
 --DB28EC13A6576C8F20B92FD0
-Content-Type: text/html
+Content-Type: text/html; charset=utf-8
 Content-Transfer-Encoding: quoted-printable
 
 <h1>Some HTML</h1>

--- a/test/fixtures/recursive-part-rendering.eml
+++ b/test/fixtures/recursive-part-rendering.eml
@@ -1,13 +1,13 @@
 Content-Type: multipart/alternative; boundary="foobar"
 
 --foobar
-Content-Type: text/plain
+Content-Type: text/plain; charset=utf-8
 Content-Transfer-Encoding: quoted-printable
 
 Hello there! 1 + 1 =3D 2
 
 --foobar
-Content-Type: text/html
+Content-Type: text/html; charset=utf-8
 Content-Transfer-Encoding: quoted-printable
 
 <a href=3D"/">Hello there! 1 + 1 =3D 2</a>

--- a/test/fixtures/simple-multipart-rendering.eml
+++ b/test/fixtures/simple-multipart-rendering.eml
@@ -6,13 +6,13 @@ Mime-Version: 1.0
 Content-Type: multipart/alternative; boundary="foobar"
 
 --foobar
-Content-Type: text/plain
+Content-Type: text/plain; charset=utf-8
 Content-Transfer-Encoding: quoted-printable
 
 Some text
 
 --foobar
-Content-Type: text/html
+Content-Type: text/html; charset=utf-8
 Content-Transfer-Encoding: quoted-printable
 
 <h1>Some HTML</h1>

--- a/test/fixtures/simple-plain-rendering.eml
+++ b/test/fixtures/simple-plain-rendering.eml
@@ -1,6 +1,6 @@
 To: user@example.com
 Subject: Test email
-Content-Type: text/plain
+Content-Type: text/plain; charset=utf-8
 Content-Transfer-Encoding: quoted-printable
 
 Some text

--- a/test/mail/message_test.exs
+++ b/test/mail/message_test.exs
@@ -108,14 +108,14 @@ defmodule Mail.MessageTest do
 
   test "build_text" do
     message = Mail.Message.build_text("Some text")
-    assert Mail.Message.get_content_type(message) == ["text/plain"]
+    assert Mail.Message.get_content_type(message) == ["text/plain; charset=utf-8"]
     assert Mail.Message.get_header(message, :content_transfer_encoding) == :quoted_printable
     assert message.body == "Some text"
   end
 
   test "build_html" do
     message = Mail.Message.build_html("<h1>Some HTML</h1>")
-    assert Mail.Message.get_content_type(message) == ["text/html"]
+    assert Mail.Message.get_content_type(message) == ["text/html; charset=utf-8"]
     assert Mail.Message.get_header(message, :content_transfer_encoding) == :quoted_printable
     assert message.body == "<h1>Some HTML</h1>"
   end
@@ -164,5 +164,21 @@ defmodule Mail.MessageTest do
 
     message = Mail.Message.put_body(%Mail.Message{}, "test body")
     refute Mail.Message.is_attachment?(message)
+  end
+
+  describe "charset_for_text_parts" do
+    test "defaults to utf-8" do
+      mail = Mail.put_text(Mail.build(), "Some text")
+      assert Mail.Message.get_content_type(mail) == ["text/plain; charset=utf-8"]
+
+      mail = Mail.put_html(Mail.build(), "<h1>Some HTML</h1>")
+      assert Mail.Message.get_content_type(mail) == ["text/html; charset=utf-8"]
+    end
+
+    test "unsetting charset" do
+      mail = Mail.put_text(Mail.build() |> Mail.Message.put_charset_for_text_parts(nil), "Some text")
+
+      assert Mail.Message.get_content_type(mail) == ["text/plain"]
+    end
   end
 end

--- a/test/mail_test.exs
+++ b/test/mail_test.exs
@@ -137,7 +137,7 @@ defmodule MailTest do
 
     assert length(mail.parts) == 0
     assert mail.body == "Some text"
-    assert Mail.Message.get_content_type(mail) == ["text/plain"]
+    assert Mail.Message.get_content_type(mail) == ["text/plain; charset=utf-8"]
   end
 
   test "put_text with a multipart" do
@@ -147,7 +147,7 @@ defmodule MailTest do
     part = List.first(mail.parts)
 
     assert part.body == "Some text"
-    assert Mail.Message.get_content_type(part) == ["text/plain"]
+    assert Mail.Message.get_content_type(part) == ["text/plain; charset=utf-8"]
   end
 
   test "put_text replaces existing text part in multipart" do
@@ -159,7 +159,7 @@ defmodule MailTest do
     part = List.first(mail.parts)
 
     assert part.body == "Some other text"
-    assert Mail.Message.get_content_type(part) == ["text/plain"]
+    assert Mail.Message.get_content_type(part) == ["text/plain; charset=utf-8"]
   end
 
   test "get_text with singlepart" do
@@ -210,7 +210,7 @@ defmodule MailTest do
 
     assert length(mail.parts) == 0
     assert mail.body == "<h1>Some HTML</h1>"
-    assert Mail.Message.get_content_type(mail) == ["text/html"]
+    assert Mail.Message.get_content_type(mail) == ["text/html; charset=utf-8"]
   end
 
   test "put_html with a multipart" do
@@ -220,7 +220,7 @@ defmodule MailTest do
     part = List.first(mail.parts)
 
     assert part.body == "<h1>Some HTML</h1>"
-    assert Mail.Message.get_content_type(part) == ["text/html"]
+    assert Mail.Message.get_content_type(part) == ["text/html; charset=utf-8"]
   end
 
   test "put_html replaces existing html part in multipart" do
@@ -232,7 +232,7 @@ defmodule MailTest do
     part = List.first(mail.parts)
 
     assert part.body == "<h1>Some other html</h1>"
-    assert Mail.Message.get_content_type(part) == ["text/html"]
+    assert Mail.Message.get_content_type(part) == ["text/html; charset=utf-8"]
   end
 
   test "get_html with singlepart" do

--- a/test/mail_test.exs
+++ b/test/mail_test.exs
@@ -187,7 +187,8 @@ defmodule MailTest do
 
   test "get_text with multipart and multiple values" do
     text = "I am the body!"
-    mail = 
+
+    mail =
       Mail.Message.put_part(
         Mail.build_multipart(),
         Mail.Message.put_content_type(%Mail.Message{}, "text/plain; charset=UTF-8; format=flowed")
@@ -195,7 +196,7 @@ defmodule MailTest do
         |> Mail.Message.put_body(text)
       )
 
-    parsed_mail = 
+    parsed_mail =
       mail
       |> Mail.render()
       |> Mail.Parsers.RFC2822.parse()


### PR DESCRIPTION
There might be better options for this, such as accepting a tuple `{:encoding, binary}` in `build_html/build_text`, however that would have meant also forking and changing other libs (bamboo_ses_adapter). 